### PR TITLE
Fixed links to posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Completed features will be added here as each stage is complete.
 
 ## Structure Quick Reference
 
-For details about design concepts, constraints, and how structural elements interact, see the article and/or Youtube video [Anatomy of a NixOS Config](https://unmovedcentre.com/technology/2024/02/24/anatomy-of-a-nixos-config.html) available on my website.
+For details about design concepts, constraints, and how structural elements interact, see the article and/or Youtube video [Anatomy of a NixOS Config](https://unmovedcentre.com/posts/anatomy-of-a-nixos-config/) available on my website.
 
 For a large screenshot of the concept diagram, as well as previous iterations, see [Anatomy](docs/anatomy.md).
 

--- a/docs/anatomy.md
+++ b/docs/anatomy.md
@@ -9,7 +9,7 @@ The following diagram depicts the conceptual anatomy of my nix-config. It is not
 
 ## Details
 
-For details about the design concepts, constraints, and how structural elements interact, see the article and/or Youtube video [Anatomy of a NixOS Config](https://unmovedcentre.com/technology/2024/02/24/anatomy-of-a-nixos-config.html) available on my website.
+For details about the design concepts, constraints, and how structural elements interact, see the article and/or Youtube video [Anatomy of a NixOS Config](https://unmovedcentre.com/posts/anatomy-of-a-nixos-config/) available on my website.
 
 ## Previous Iterations of the Structural Concept
 

--- a/docs/secretsmgmt.md
+++ b/docs/secretsmgmt.md
@@ -2,4 +2,4 @@
 
 [README](../README.md) > Nix-Config Secrets Management
 
-This content has been updated and moved to my website [NixOS Secrets Management](https://unmovedcentre.com/technology/2024/02/24/anatomy-of-a-nixos-config.html). There is also an accompanying [video series](https://youtu.be/6EMNHDOY-wo).
+This content has been updated and moved to my website [NixOS Secrets Management](https://unmovedcentre.com/posts/secrets-management/). There is also an accompanying [video series](https://youtu.be/6EMNHDOY-wo).


### PR DESCRIPTION
Some links were to an empty address of the written posts, substituted them with the current versions.