### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ I intentionally keep all of my content ad-free.
 - [NixOS & Flakes Book](https://nixos-and-flakes.thiscute.world/) - an excellent introductory book by Ryan Yin
 - [Impermanence](https://github.com/nix-community/impermanence)
 - Yubikey
-  - <https://nixos.wiki/wiki/Yubikey>
+  - <https://wiki.nixos.org/wiki/Yubikey>
   - [DrDuh YubiKey-Guide](https://github.com/drduh/YubiKey-Guide)
 
 ## Acknowledgements

--- a/hosts/grief/default.nix
+++ b/hosts/grief/default.nix
@@ -82,9 +82,9 @@
 };
 
 # This is a fix to enable VSCode to successfully remote SSH on a client to a NixOS host
-# https://nixos.wiki/wiki/Visual_Studio_Code # Remote_SSH
+# https://wiki.nixos.org/wiki/Visual_Studio_Code # Remote_SSH
 programs.nix-ld.enable = true;
 
-# https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+# https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
 system.stateVersion = "23.11";
 }

--- a/hosts/guppy/default.nix
+++ b/hosts/guppy/default.nix
@@ -54,6 +54,6 @@
     systemd.enable = true;
   };
 
-  # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+  # https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
   system.stateVersion = "23.11";
 }

--- a/hosts/gusto/default.nix
+++ b/hosts/gusto/default.nix
@@ -57,6 +57,6 @@
     systemd.enable = true;
   };
 
-  # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+  # https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
   system.stateVersion = "23.05";
 }

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,4 +1,4 @@
-# Add your reusable home-manager modules to this directory, on their own file (https://nixos.wiki/wiki/Module).
+# Add your reusable home-manager modules to this directory, on their own file (https://wiki.nixos.org/wiki/Module).
 # These should be stuff you would like to share with others, not your personal configurations.
 {
   # List your module files here

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,4 @@
-# Add your reusable NixOS modules to this directory, on their own file (https://nixos.wiki/wiki/Module).
+# Add your reusable NixOS modules to this directory, on their own file (https://wiki.nixos.org/wiki/Module).
 # These should be stuff you would like to share with others, not your personal configurations.
 {
   # List your module files here

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -8,7 +8,7 @@
 
   # This one contains whatever you want to overlay
   # You can change versions, add patches, set compilation flags, anything really.
-  # https://nixos.wiki/wiki/Overlays
+  # https://wiki.nixos.org/wiki/Overlays
   modifications = final: prev: {
     # example = prev.example.overrideAttrs (oldAttrs: let ... in {
     # ...


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️