### PR TITLE
Add warnings module and silence the ambiguous password warning

### DIFF
--- a/hosts/common/core/default.nix
+++ b/hosts/common/core/default.nix
@@ -28,6 +28,12 @@ in
     flake = "${homeDirectory}/nix-config";
   };
 
+  configOptions.silencedWarnings = [
+    # see https://github.com/NixOS/nixpkgs/pull/287506 for more information
+    "The user '${configVars.username}' has multiple of the options\n`hashedPassword`, `password`, `hashedPasswordFile`, `initialPassword`\n& `initialHashedPassword` set to a non-null value.\nThe options silently discard others by the order of precedence\ngiven above which can lead to surprising results. To resolve this warning,\nset at most one of the options above to a non-`null` value.\n\nThe values of these options are:\n* users.users.\"${configVars.username}\".hashedPassword: null\n* users.users.\"${configVars.username}\".hashedPasswordFile: \"/run/secrets-for-users/${configVars.username}/password\"\n* users.users.\"${configVars.username}\".password: \"nixos\"\n"
+    "The user 'root' has multiple of the options\n`hashedPassword`, `password`, `hashedPasswordFile`, `initialPassword`\n& `initialHashedPassword` set to a non-null value.\nThe options silently discard others by the order of precedence\ngiven above which can lead to surprising results. To resolve this warning,\nset at most one of the options above to a non-`null` value.\n\nThe values of these options are:\n* users.users.\"root\".hashedPassword: null\n* users.users.\"root\".hashedPasswordFile: \"/run/secrets-for-users/${configVars.username}/password\"\n* users.users.\"root\".password: \"nixos\"\n"
+  ];
+
   # This should be handled by config.security.pam.sshAgentAuth.enable
   security.sudo.extraConfig = ''
     Defaults lecture = never # rollback results in sudo lectures after each reboot, it's somewhat useless anyway

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -5,4 +5,5 @@
   backup = import ./backup;
   semi-active-av = import ./semi-active-av.nix;
   yubikey = import ./yubikey;
+  warnings = import ./warnings.nix;
 }

--- a/modules/nixos/warnings.nix
+++ b/modules/nixos/warnings.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+{
+  # mostly copied from https://git.uninsane.org/colin/nix-files/src/branch/master/modules/warnings.nix
+  options = with lib; {
+    configOptions.silencedWarnings = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        list of `config.warnings` values you want to ignore, verbatim.
+      '';
+    };
+    warnings = mkOption {
+      apply = builtins.filter (w: !(builtins.elem w config.configOptions.silencedWarnings));
+    };
+  };
+}


### PR DESCRIPTION
Yet another pull request you may or may not want to merge. I finally decided this was annoying me enough to fix, this PR removes an evaluation warning that appears on every rebuild:
```
The user '${user.name}' has multiple of the options
        `hashedPassword`, `password`, `hashedPasswordFile`, `initialPassword`
        & `initialHashedPassword` set to a non-null value.
        The options silently discard others by the order of precedence
        given above which can lead to surprising results. To resolve this warning,
        set at most one of the options above to a non-`null` value.
```

Since this is intentionally done to make sure a backup password is set in the event that secrets don't work correctly, this warning really isn't needed. _A recent PR in nixpkgs made this even worse, now it dumps the 'conflicting' values too, making it even longer._