### PR TITLE
Fix home-manager options in nixd

### DIFF
--- a/home/ta/common/core/nixvim/plugins/lspconfig.nix
+++ b/home/ta/common/core/nixvim/plugins/lspconfig.nix
@@ -57,8 +57,7 @@ in
                   };
                   home_manager = {
                     expr = ''
-                      let configs = (builtins.getFlake ${flakeRoot}).homeConfigurations;
-                      in (builtins.head (builtins.attrValues configs)).options
+                      (builtins.getFlake "${flakeRoot}").nixosConfigurations.${config.hostSpec.hostName}.options.home-manager.users.value.${config.hostSpec.username}
                     '';
                   };
                   darwin = {


### PR DESCRIPTION
The old solutions did not work since there is no homeConfigurations in flake.nix. Instead  all home manager options are defined under nixosConfigurations.<hostname>.options.home-manager.users.value.<username>.

I have a similar solution in my commit: 
https://github.com/JakobEdvardsson/nix-config/commit/a59cf727fbed4808900c0a4cb03c23134bcb4765
