### PR TITLE
refactor: simplify host definitions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,14 @@
 {
   description = "EmergentMind's Nix-Config";
   outputs =
-    { self, nixpkgs, ... }@inputs:
+    {
+      self,
+      nixpkgs,
+      # nix-darwin,
+      ...
+    }@inputs:
     let
       inherit (self) outputs;
-      inherit (nixpkgs) lib;
 
       #
       # ========= Architectures =========
@@ -14,38 +18,11 @@
         #"aarch64-darwin"
       ];
 
-      #
-      # ========= Host Config Functions =========
-      #
-      # Handle a given host config based on whether its underlying system is nixos or darwin
-      mkHost = host: isDarwin: {
-        ${host} =
-          let
-            func = if isDarwin then inputs.nix-darwin.lib.darwinSystem else lib.nixosSystem;
-            systemFunc = func;
-          in
-          systemFunc {
-            specialArgs = {
-              inherit
-                inputs
-                outputs
-                isDarwin
-                ;
+      # ========== Extend lib with lib.custom ==========
+      # NOTE: This approach allows lib.custom to propagate into hm
+      # see: https://github.com/nix-community/home-manager/pull/3454
+      lib = nixpkgs.lib.extend (self: super: { custom = import ./lib { inherit (nixpkgs) lib; }; });
 
-              # ========== Extend lib with lib.custom ==========
-              # NOTE: This approach allows lib.custom to propagate into hm
-              # see: https://github.com/nix-community/home-manager/pull/3454
-              lib = nixpkgs.lib.extend (self: super: { custom = import ./lib { inherit (nixpkgs) lib; }; });
-
-            };
-            modules = [ ./hosts/${if isDarwin then "darwin" else "nixos"}/${host} ];
-          };
-      };
-      # Invoke mkHost for each host config that is declared for either nixos or darwin
-      mkHostConfigs =
-        hosts: isDarwin: lib.foldl (acc: set: acc // set) { } (lib.map (host: mkHost host isDarwin) hosts);
-      # Return the hosts declared in the given directory
-      readHosts = folder: lib.attrNames (builtins.readDir ./hosts/${folder});
     in
     {
       #
@@ -58,8 +35,31 @@
       # ========= Host Configurations =========
       #
       # Building configurations is available through `just rebuild` or `nixos-rebuild --flake .#hostname`
-      nixosConfigurations = mkHostConfigs (readHosts "nixos") false;
-      #darwinConfigurations = mkHostConfigs (readHosts "darwin") true;
+      nixosConfigurations = builtins.listToAttrs (
+        map (host: {
+          name = host;
+          value = nixpkgs.lib.nixosSystem {
+            specialArgs = {
+              inherit inputs outputs lib;
+              isDarwin = false;
+            };
+            modules = [ ./hosts/nixos/${host} ];
+          };
+        }) (builtins.attrNames (builtins.readDir ./hosts/nixos))
+      );
+
+      # darwinConfigurations = builtins.listToAttrs (
+      #   map (host: {
+      #     name = host;
+      #     value = nix-darwin.lib.darwinSystem {
+      #       specialArgs = {
+      #         inherit inputs outputs lib;
+      #         isDarwin = true;
+      #       };
+      #       modules = [ ./hosts/darwin/${host} ];
+      #     };
+      #   }) (builtins.attrNames (builtins.readDir ./hosts/darwin))
+      # );
 
       #
       # ========= Packages =========
@@ -73,8 +73,8 @@
             overlays = [ self.overlays.default ];
           };
         in
-        lib.packagesFromDirectoryRecursive {
-          callPackage = lib.callPackageWith pkgs;
+        nixpkgs.lib.packagesFromDirectoryRecursive {
+          callPackage = nixpkgs.lib.callPackageWith pkgs;
           directory = ./pkgs/common;
         }
       );
@@ -82,7 +82,7 @@
       #
       # ========= Formatting =========
       #
-      # Nix formatter available through 'nix fmt' https://nix-community.github.io/nixpkgs-fmt
+      # Nix formatter available through 'nix fmt' https://github.com/NixOS/nixfmt
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
       # Pre-commit checks
       checks = forAllSystems (


### PR DESCRIPTION
~~*turns out its not working*~~ should be working now?

I can't verify this is working, @EmergentMind if you could test when you get a chance. 

Feedback welcome, so far this is just simplifying the code.


EDIT: thought I'd bring it up here - I did notice the nixpkgs manual was updated to discourage [extending `lib`](https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-param-specialArgs)