### PR TITLE
doc: clarify `packages` usage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
       #
       # ========= Overlays =========
       #
-      # Custom modifications/overrides to upstream packages.
+      # Custom modifications/overrides to upstream packages
       overlays = import ./overlays { inherit inputs; };
 
       #
@@ -64,7 +64,13 @@
       #
       # ========= Packages =========
       #
-      # Add custom packages to be shared or upstreamed.
+      # Expose custom packages
+
+      /*
+        NOTE: This is only for exposing packages exterally; ie, `nix build .#packages.x86_64-linux.cd-gitroot`
+        For internal use, these packages are added through the default overlay in `overlays/default.nix`
+      */
+
       packages = forAllSystems (
         system:
         let


### PR DESCRIPTION
_A bit of an extension of #26 - Open to suggestions on wording/formatting_

Currently, it isn't immediately obvious that, internally, custom packages are actually added through `overlays`/`overlays/default.nix`, not `packages`, and this is seemingly confusing people who are unfamiliar with this repo/flakes/nix.